### PR TITLE
[Fixed verification of start and stop values in tags]

### DIFF
--- a/Start.ps1
+++ b/Start.ps1
@@ -43,7 +43,7 @@ function Get-AzureRmVMStatus {
     [string]
     $Name = '*'
   )
-  Get-AzureRmVM -ResourceGroupName $ResourceGroupName | ? {$_.Tags.Keys -eq "Start" -and $_.Tags.Values -eq "$StartType"} |
+  Get-AzureRmVM -ResourceGroupName $ResourceGroupName | ? {$_.Tags["Start"] -eq "$StartType"} |
     Get-AzureRmVM -Status |
     Select-Object -Property Name, Statuses, ResourceGroupName |
     Where-Object {$_.Name -like $Name} |

--- a/Stop.ps1
+++ b/Stop.ps1
@@ -43,7 +43,7 @@ function Get-AzureRmVMStatus {
     [string]
     $Name = '*'
   )
-  Get-AzureRmVM -ResourceGroupName $ResourceGroupName | ? {$_.Tags.Keys -eq "Stop" -and $_.Tags.Values -eq "$StopType"} |
+  Get-AzureRmVM -ResourceGroupName $ResourceGroupName | ? {$_.Tags["Stop"] -eq "$StopType"} |
     Get-AzureRmVM -Status |
     Select-Object -Property Name, Statuses, ResourceGroupName |
     Where-Object {$_.Name -like $Name} |


### PR DESCRIPTION
Because the Keys and Values collections of VM's Tags property are checked separately the following configuration makes the VM starts anyway:

Start=None
Stop=Auto

so following expression
{$_.Tags.Keys -eq "Start" -and $_.Tags.Values -eq "$StartType"}

can be changed as follows
{$_.Tags["Start"] -eq "$StartType"}

Same for VM's Stop

